### PR TITLE
Force LF line endings for shell scripts via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts get mounted straight into Linux containers and executed
+# there, so they must always check out with LF endings regardless of a
+# developer's local core.autocrlf setting - a stray \r breaks the Linux
+# shell (e.g. "$'\r': command not found").
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
On Windows, `core.autocrlf=true` (Git's own recommended setting for Windows installs) converts LF line endings to CRLF on checkout for any file Git treats as text. With no `.gitattributes` in the repo, shell scripts get checked out with CRLF. Scripts that are bind-mounted straight into Linux containers and executed there (e.g. `ndx/config/thunderid/bootstrap/02-admin-cli.sh`) then fail, since a plain Linux shell doesn't strip `\r` and errors with `$'\r': command not found` on any line that ends up containing only a stray carriage return.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Added `.gitattributes` forcing `*.sh text eol=lf`, so shell scripts always check out with LF line endings regardless of a developer's local `core.autocrlf` setting.

## Testing
- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [ ] All existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Additional Notes
Found while debugging a `thunderid-setup` container failure on Windows (CRLF-corrupted bootstrap script), but the underlying checkout issue is repo-wide for any `.sh` file, not specific to that one script.