### PR TITLE
fix: use localhost as the OIDC issuer to drop the /etc/hosts requirement

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -298,7 +298,7 @@ ThunderID container:
 
 ```bash
 # Extract ThunderID's signing public key (PEM)
-docker cp "$(cd ndx && docker-compose ps -q thunderid):/opt/thunderid/config/certs/signing.cert" /tmp/signing.cert
+docker cp "$([ -d ndx ] && cd ndx; docker-compose ps -q thunderid):/opt/thunderid/config/certs/signing.cert" /tmp/signing.cert
 PUBLIC_KEY=$(openssl x509 -in /tmp/signing.cert -pubkey -noout)
 
 # Register the OE route (jq inlines the PEM with correct JSON escaping)

--- a/SETUP.md
+++ b/SETUP.md
@@ -60,35 +60,19 @@ git clone https://github.com/opendif/opendif-farajaland.git
 cd opendif-farajaland
 ```
 
-### 2. Configure Hostname Resolution
+### 2. Hostname Resolution (No Action Needed)
 
-Since ThunderID runs inside the Docker network with the hostname `thunderid`, you need to add this hostname to your `/etc/hosts` file for proper DNS resolution:
+**No `/etc/hosts` changes are required.**
 
-**macOS/Linux:**
-```bash
-# Add thunderid hostname to /etc/hosts
-echo "127.0.0.1       thunderid" | sudo tee -a /etc/hosts
-```
+ThunderID's OIDC issuer is `https://localhost:8090`. Your browser reaches it
+directly, and the containers reach ThunderID over the Docker network — so a single
+issuer works everywhere with no host-file edits and no host-IP detection.
 
-**Windows:**
-1. Open Notepad as Administrator
-2. Open `C:\Windows\System32\drivers\etc\hosts`
-3. Add the following line at the end:
-   ```
-   127.0.0.1       thunderid
-   ```
-4. Save the file
-
-**Verify the configuration:**
-```bash
-ping thunderid
-```
-
-Once ThunderID is running, open `https://thunderid:8090` in your browser once and
-accept the self-signed certificate warning — otherwise the Consent Portal's
-redirect to ThunderID's login page will silently fail with a TLS error.
-
-You should see responses from `127.0.0.1`.
+> **Accept the self-signed certificate once.** ThunderID serves a self-signed dev
+> certificate (issued for `localhost`). After `init.sh` reports the services are
+> healthy, open `https://localhost:8090` in your browser once and accept the
+> certificate warning — otherwise the Consent Portal's redirect to ThunderID's
+> login page will silently fail with a TLS error.
 
 ### 3. Make the Initialization Script Executable
 
@@ -182,7 +166,7 @@ Client Secret:
   • Use these credentials to call the publicly exposed endpoints
 
 Token Endpoint:
-https://thunderid:8090/oauth2/token
+https://localhost:8090/oauth2/token
 
 Public API Gateway:
 http://localhost:9081/public/*
@@ -290,13 +274,16 @@ an `ADMIN_CLI` M2M client with management API access during `docker-compose up`,
 you can create the required applications with curl instead of a browser console:
 
 ```bash
+# Run from the host shell, which reaches ThunderID at the published localhost:8090
+# port - no /etc/hosts entry needed.
+
 # Mint a management token from the ADMIN_CLI client created during bootstrap
 TOKEN=$(curl -k -s -u "ADMIN_CLI:${ADMIN_CLI_SECRET:-1234}" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=client_credentials" -d "scope=system" \
-  https://thunderid:8090/oauth2/token | jq -r .access_token)
+  https://localhost:8090/oauth2/token | jq -r .access_token)
 
-# Use $TOKEN as a Bearer token against https://thunderid:8090/applications
+# Use $TOKEN as a Bearer token against https://localhost:8090/applications
 # (POST) to create an M2M application for the API Gateway and an SPA
 # application for the Consent Portal. Note down the client IDs and secrets.
 ```
@@ -305,34 +292,46 @@ Or simply run `./init.sh`, which performs all of this automatically.
 
 ### Step 3: Register API Gateway Routes
 
-Update the APISIX routes with your client credentials:
+Register the APISIX routes. APISIX verifies each token's RS256 signature locally
+against ThunderID's signing public key, so first extract that key from the
+ThunderID container:
 
 ```bash
-# Replace $CLIENT_ID and $CLIENT_SECRET with your values
-curl --location --request PUT http://localhost:9180/apisix/admin/routes \
-  --header "Content-Type: application/json" \
-  --header "X-API-KEY: QuNGwapKysRvHfUtNkQFbUaGiiYeOcGo" \
-  --data '{
-    "uri": "/public/*",
-    "methods": ["GET", "POST"],
-    "upstream": {
-      "type": "roundrobin",
-      "nodes": {
-        "orchestration-engine:4000": 1
-      }
-    },
-    "plugins": {
+# Extract ThunderID's signing public key (PEM)
+docker cp "$(cd ndx && docker-compose ps -q thunderid):/opt/thunderid/config/certs/signing.cert" /tmp/signing.cert
+PUBLIC_KEY=$(openssl x509 -in /tmp/signing.cert -pubkey -noout)
+
+# Register the OE route (jq inlines the PEM with correct JSON escaping)
+jq -n --arg pk "$PUBLIC_KEY" '{
+    uri: "/public/*",
+    methods: ["GET", "POST"],
+    upstream: { type: "roundrobin", nodes: { "orchestration-engine:4000": 1 } },
+    plugins: {
       "openid-connect": {
-        "discovery": "https://thunderid:8090/.well-known/openid-configuration",
-        "bearer_only": true,
-        "client_id": "YOUR_CLIENT_ID",
-        "client_secret": "YOUR_CLIENT_SECRET",
-        "ssl_verify": false
+        client_id: "ndx-api-gateway",
+        discovery: "https://localhost:8090/.well-known/openid-configuration",
+        bearer_only: true,
+        public_key: $pk,
+        token_signing_alg_values_expected: "RS256",
+        claim_validator: { issuer: { valid_issuers: ["https://localhost:8090"] } },
+        set_userinfo_header: true,
+        ssl_verify: false
       }
     },
-    "id": "oe-endpoint"
-  }'
+    id: "oe-endpoint"
+  }' | curl --location --request PUT http://localhost:9180/apisix/admin/routes \
+    --header "Content-Type: application/json" \
+    --header "X-API-KEY: QuNGwapKysRvHfUtNkQFbUaGiiYeOcGo" \
+    --data @-
 ```
+
+> **Why local (public_key) validation instead of JWKS?** With the issuer set to
+> `https://localhost:8090`, the JWKS URL advertised in the discovery document is
+> `https://localhost:8090/oauth2/jwks`, which the APISIX container cannot reach
+> (`localhost` there means APISIX itself). Verifying the RS256 signature locally
+> against ThunderID's public key needs no network call to the IdP — the `localhost`
+> issuer is only ever compared as a string (`valid_issuers`), never dereferenced.
+> `client_id` is required by the plugin schema but unused for local verification.
 
 ### Step 4: Start Member Services
 

--- a/init.sh
+++ b/init.sh
@@ -449,12 +449,20 @@ if [ -z "$THUNDERID_CID" ]; then
     print_error "Could not find the thunderid container to extract its signing key"
     exit 1
 fi
+if ! command -v openssl >/dev/null 2>&1; then
+    print_error "'openssl' is not installed on the host; it is required to extract the signing public key"
+    exit 1
+fi
 SIGNING_CERT_FILE="$(mktemp)"
-docker cp "${THUNDERID_CID}:/opt/thunderid/config/certs/signing.cert" "$SIGNING_CERT_FILE" >/dev/null 2>&1
+if ! docker cp "${THUNDERID_CID}:/opt/thunderid/config/certs/signing.cert" "$SIGNING_CERT_FILE" >/dev/null 2>&1; then
+    print_error "Failed to copy the signing certificate from the thunderid container"
+    rm -f "$SIGNING_CERT_FILE"
+    exit 1
+fi
 IDP_PUBLIC_KEY=$(openssl x509 -in "$SIGNING_CERT_FILE" -pubkey -noout 2>/dev/null)
 rm -f "$SIGNING_CERT_FILE"
 if [ -z "$IDP_PUBLIC_KEY" ]; then
-    print_error "Failed to extract ThunderID signing public key (is openssl installed?)"
+    print_error "Failed to extract the ThunderID signing public key from the certificate"
     exit 1
 fi
 print_success "Extracted ThunderID signing public key"
@@ -502,6 +510,7 @@ CE_ROUTE_CODE=$(jq -n \
   --arg client_id "$CLIENT_ID" \
   --arg discovery "https://thunderid:${IDP_PORT}/.well-known/openid-configuration" \
   --arg issuer "$ISSUER_URL" \
+  --arg cors_origin "${CONSENT_PORTAL_URL:-http://localhost:5173}" \
   '{
     uri: "/api/v1/consents/*",
     methods: ["GET", "PUT", "OPTIONS"],
@@ -519,7 +528,7 @@ CE_ROUTE_CODE=$(jq -n \
         access_token_in_authorization_header: true
       },
       "cors": {
-        allow_origins: "http://localhost:5173",
+        allow_origins: $cors_origin,
         allow_headers: "*",
         allow_methods: "GET,PUT,OPTIONS"
       }

--- a/init.sh
+++ b/init.sh
@@ -249,27 +249,27 @@ thunderid_api_call() {
 }
 
 # Configure server-wide CORS allowed origins. ThunderID 0.48 removed the static
-# `cors` block from deployment.yaml; CORS is now a server-config section. The
-# browser-facing apps call /oauth2/token cross-origin - the Console served from
-# the issuer (https://localhost:8090) and the Consent Portal (CONSENT_PORTAL_APP)
-# from http://localhost:5173 - so their origins must be allowed here. This sets the
-# writable layer (PUT /server-config/cors), which is DB-backed and read by the
-# running server's dynamic CORS matcher.
+# `cors` block from deployment.yaml; CORS is now a server-config section. Only the
+# Consent Portal (CONSENT_PORTAL_APP, http://localhost:5173) calls /oauth2/token
+# cross-origin, so it is the only origin that needs allowing. The ThunderID Console
+# is served from the issuer itself (https://localhost:8090), so its /oauth2/token
+# calls are same-origin and need no CORS entry. This sets the writable layer
+# (PUT /server-config/cors), which is DB-backed and read by the running server's
+# dynamic CORS matcher.
 configure_cors() {
     local CONSENT_PORTAL_ORIGIN="${CONSENT_PORTAL_URL:-http://localhost:5173}"
     local RESPONSE HTTP_CODE CORS_PAYLOAD
     read -r -d '' CORS_PAYLOAD <<JSON || true
 {
     "allowedOrigins": [
-        "${CONSENT_PORTAL_ORIGIN}",
-        "https://localhost:${IDP_PORT}"
+        "${CONSENT_PORTAL_ORIGIN}"
     ]
 }
 JSON
     RESPONSE=$(thunderid_api_call PUT "/server-config/cors" "$CORS_PAYLOAD")
     HTTP_CODE="${RESPONSE: -3}"
     if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
-        print_success "Configured CORS allowed origins (Console + Consent Portal)"
+        print_success "Configured CORS allowed origins (Consent Portal)"
     else
         print_warning "Failed to configure CORS allowed origins (HTTP $HTTP_CODE) - browser apps may hit CORS errors"
     fi

--- a/init.sh
+++ b/init.sh
@@ -122,73 +122,18 @@ fi
 echo ""
 
 
-# Detect machine IP address for Rancher Desktop compatibility
-detect_host_ip() {
-    local ip=""
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        # macOS - try different interfaces
-        for interface in en0 en1; do
-            ip=$(ipconfig getifaddr "$interface" 2>/dev/null)
-            # Validate IPv4 format
-            if [ -n "$ip" ] && [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-                echo "$ip"
-                return 0
-            fi
-        done
-    elif [[ "$OSTYPE" == msys* ]] || [[ "$OSTYPE" == cygwin* ]] || [[ "$OSTYPE" == win32 ]]; then
-        # Windows (Git Bash / MSYS / Cygwin) - `ipconfig` output ordering isn't
-        # stable (virtual adapters like Hyper-V/WSL can list before the real
-        # LAN adapter), so parsing it is unreliable. Docker Desktop registers
-        # host.docker.internal in the Windows hosts file too, so it resolves
-        # correctly from both the host shell and from inside containers.
-        echo "host.docker.internal"
-        return 0
-    else
-        # Linux - get first IPv4 address (filter out IPv6)
-        ip=$(hostname -I 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/) {print $i; exit}}')
-        if [ -n "$ip" ]; then
-            echo "$ip"
-            return 0
-        fi
-    fi
-
-    # Fallback: Try Docker gateway
-    if command -v docker &> /dev/null && docker info &> /dev/null; then
-        ip=$(docker run --rm --net host alpine ip route 2>/dev/null | awk '/default/ {print $3}' | head -1)
-        if [ -n "$ip" ] && [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            echo "$ip"
-            return 0
-        fi
-    fi
-
-    return 1
-}
-
-print_info "Detecting host machine IP address..."
-HOST_IP="${HOST_IP:-$(detect_host_ip)}"
-
-if [ -z "$HOST_IP" ] || [ "$HOST_IP" = "null" ]; then
-    print_error "Failed to detect host IP address"
-    print_info "For Rancher Desktop, set HOST_IP manually:"
-    print_info "  export HOST_IP=\$(hostname -I | awk '{print \$1}')"
-    print_info "  # Or use: export HOST_IP=host.docker.internal"
-    exit 1
-fi
-
-# Validate IP format
-if [[ ! $HOST_IP =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]] && [ "$HOST_IP" != "host.docker.internal" ]; then
-    print_error "Invalid HOST_IP format: $HOST_IP"
-    exit 1
-fi
-
-print_success "Detected the Host Machine IP: $HOST_IP"
-export HOST_IP
-
-# Initialize Variables
-THUNDERID_URL=${HOST_IP}:${IDP_PORT:-8090}
-ADMIN_CLI_SECRET="${ADMIN_CLI_SECRET:-1234}"
+# Initialize Variables. init.sh runs on the host, so it reaches ThunderID at the
+# published localhost:8090 port - no /etc/hosts entry and no host-IP detection are
+# needed for this local-only stack.
 export IDP_PORT="${IDP_PORT:-8090}"
+THUNDERID_URL=localhost:${IDP_PORT}
+ADMIN_CLI_SECRET="${ADMIN_CLI_SECRET:-1234}"
+
+# The OIDC issuer is https://localhost:8090 (set in ndx/.env). The browser reaches
+# it directly and ThunderID's dev cert is CN=localhost, so the cert matches, and
+# consent-engine validates the token `iss` against this string. JWKS is fetched
+# server-side by consent-engine over Docker DNS (thunderid:8090).
+ISSUER_URL="https://localhost:${IDP_PORT}"
 
 # Start NDX infrastructure services
 print_info "Starting NDX infrastructure services (docker-compose)..."
@@ -306,10 +251,10 @@ thunderid_api_call() {
 # Configure server-wide CORS allowed origins. ThunderID 0.48 removed the static
 # `cors` block from deployment.yaml; CORS is now a server-config section. The
 # browser-facing apps call /oauth2/token cross-origin - the Console served from
-# https://localhost:8090 (and https://thunderid:8090) and the Consent Portal
-# (CONSENT_PORTAL_APP) from http://localhost:5173 - so their origins must be
-# allowed here. This sets the writable layer (PUT /server-config/cors), which is
-# DB-backed and read by the running server's dynamic CORS matcher.
+# the issuer (https://localhost:8090) and the Consent Portal (CONSENT_PORTAL_APP)
+# from http://localhost:5173 - so their origins must be allowed here. This sets the
+# writable layer (PUT /server-config/cors), which is DB-backed and read by the
+# running server's dynamic CORS matcher.
 configure_cors() {
     local CONSENT_PORTAL_ORIGIN="${CONSENT_PORTAL_URL:-http://localhost:5173}"
     local RESPONSE HTTP_CODE CORS_PAYLOAD
@@ -317,8 +262,7 @@ configure_cors() {
 {
     "allowedOrigins": [
         "${CONSENT_PORTAL_ORIGIN}",
-        "https://localhost:${IDP_PORT}",
-        "https://thunderid:${IDP_PORT}"
+        "https://localhost:${IDP_PORT}"
     ]
 }
 JSON
@@ -478,101 +422,117 @@ fi
 echo ""
 
 # Step 2: Create the API Gateway M2M application.
-# No role/scope grant is needed on this app: the apisix routes below run in
-# bearer_only + use_jwks mode, so its client_id/client_secret only satisfy the
-# openid-connect plugin's config schema, not an actual token exchange.
+# The apisix routes below validate bearer tokens by verifying their RS256 signature
+# locally against ThunderID's signing public key (extracted below). The app's
+# client_id only satisfies the openid-connect plugin's config schema (client_id is
+# a required field); its secret is not used, since local verification needs no
+# token exchange or introspection call.
 print_info "Creating M2M application for API Gateway..."
 GATEWAY_CLIENT_ID="ndx-api-gateway"
 GATEWAY_CLIENT_SECRET="${GATEWAY_CLIENT_SECRET:-$(openssl rand -hex 16)}"
 create_m2m_application "NDX_API_GATEWAY" "M2M client used by APISIX to validate bearer tokens" \
     "$GATEWAY_CLIENT_ID" "$GATEWAY_CLIENT_SECRET" "$DEFAULT_OU_ID"
 CLIENT_ID="$GATEWAY_CLIENT_ID"
-CLIENT_SECRET="$GATEWAY_CLIENT_SECRET"
 print_info "API Gateway Client ID: $CLIENT_ID"
 echo ""
 
+# Extract ThunderID's RS256 signing public key so APISIX can verify token
+# signatures locally (public_key mode). We validate locally rather than via JWKS
+# because the issuer is https://localhost:8090: the JWKS URL advertised in the
+# discovery document would be https://localhost:8090/oauth2/jwks, which the APISIX
+# container cannot reach (there, localhost means APISIX itself). Local verification
+# needs no network call to the IdP, so the issuer host is only ever compared as a
+# string (claim_validator.issuer.valid_issuers), never dereferenced.
+print_info "Extracting ThunderID signing public key for APISIX token validation..."
+THUNDERID_CID=$(docker-compose ps -q thunderid)
+if [ -z "$THUNDERID_CID" ]; then
+    print_error "Could not find the thunderid container to extract its signing key"
+    exit 1
+fi
+SIGNING_CERT_FILE="$(mktemp)"
+docker cp "${THUNDERID_CID}:/opt/thunderid/config/certs/signing.cert" "$SIGNING_CERT_FILE" >/dev/null 2>&1
+IDP_PUBLIC_KEY=$(openssl x509 -in "$SIGNING_CERT_FILE" -pubkey -noout 2>/dev/null)
+rm -f "$SIGNING_CERT_FILE"
+if [ -z "$IDP_PUBLIC_KEY" ]; then
+    print_error "Failed to extract ThunderID signing public key (is openssl installed?)"
+    exit 1
+fi
+print_success "Extracted ThunderID signing public key"
+echo ""
 
 # Register Orchestration Engine Routes
 print_info "Exposing OE Endpoints Publicly with OpenID Connect Authentication"
-curl --location --request PUT http://localhost:9180/apisix/admin/routes \
-  --header "Content-Type: application/json" \
-  --header "X-API-KEY: QuNGwapKysRvHfUtNkQFbUaGiiYeOcGo" \
-  --data @- <<EOF
-  {
-    "uri": "/public/*",
-    "methods": ["GET", "POST"],
-    "upstream": {
-      "type": "roundrobin",
-      "nodes": {
-        "orchestration-engine:4000": 1
-      }
-    },
-    "plugins": {
+OE_ROUTE_CODE=$(jq -n \
+  --arg pk "$IDP_PUBLIC_KEY" \
+  --arg client_id "$CLIENT_ID" \
+  --arg discovery "https://thunderid:${IDP_PORT}/.well-known/openid-configuration" \
+  --arg issuer "$ISSUER_URL" \
+  '{
+    uri: "/public/*",
+    methods: ["GET", "POST"],
+    upstream: { type: "roundrobin", nodes: { "orchestration-engine:4000": 1 } },
+    plugins: {
       "openid-connect": {
-        "discovery": "https://thunderid:${IDP_PORT}/.well-known/openid-configuration",
-        "bearer_only": true,
-        "token_signing_alg_values_expected": "RS256",
-        "set_userinfo_header": true,
-        "client_id": "$CLIENT_ID",
-        "client_secret": "$CLIENT_SECRET",
-        "use_jwks": true,
-        "ssl_verify": false
+        client_id: $client_id,
+        discovery: $discovery,
+        bearer_only: true,
+        public_key: $pk,
+        token_signing_alg_values_expected: "RS256",
+        claim_validator: { issuer: { valid_issuers: [$issuer] } },
+        set_userinfo_header: true,
+        ssl_verify: false
       }
     },
-    "id": "oe-endpoint"
-  }
-EOF
+    id: "oe-endpoint"
+  }' | curl -s -o /dev/null -w "%{http_code}" \
+    --location --request PUT http://localhost:9180/apisix/admin/routes \
+    --header "Content-Type: application/json" \
+    --header "X-API-KEY: QuNGwapKysRvHfUtNkQFbUaGiiYeOcGo" \
+    --data @-)
 
-if [ $? -ne 0 ]; then
-    print_error "Failed to register OE public routes"
+if [ "$OE_ROUTE_CODE" != "200" ] && [ "$OE_ROUTE_CODE" != "201" ]; then
+    print_error "Failed to register OE public routes (HTTP $OE_ROUTE_CODE)"
     exit 1
 fi
 
 print_info "Exposing Required Consent Engine Endpoints Publicly with OpenID Connect Authentication"
 
-curl --location --request PUT 'http://localhost:9180/apisix/admin/routes' \
---header 'Content-Type: application/json' \
---header 'X-API-KEY: QuNGwapKysRvHfUtNkQFbUaGiiYeOcGo' \
---data @- <<EOF
-{
-    "uri": "/api/v1/consents/*",
-    "methods": [
-        "GET",
-        "PUT",
-        "OPTIONS"
-    ],
-    "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "consent-engine:8081": 1
-        }
+CE_ROUTE_CODE=$(jq -n \
+  --arg pk "$IDP_PUBLIC_KEY" \
+  --arg client_id "$CLIENT_ID" \
+  --arg discovery "https://thunderid:${IDP_PORT}/.well-known/openid-configuration" \
+  --arg issuer "$ISSUER_URL" \
+  '{
+    uri: "/api/v1/consents/*",
+    methods: ["GET", "PUT", "OPTIONS"],
+    upstream: { type: "roundrobin", nodes: { "consent-engine:8081": 1 } },
+    plugins: {
+      "openid-connect": {
+        client_id: $client_id,
+        discovery: $discovery,
+        bearer_only: true,
+        public_key: $pk,
+        token_signing_alg_values_expected: "RS256",
+        claim_validator: { issuer: { valid_issuers: [$issuer] } },
+        set_userinfo_header: true,
+        ssl_verify: false,
+        access_token_in_authorization_header: true
+      },
+      "cors": {
+        allow_origins: "http://localhost:5173",
+        allow_headers: "*",
+        allow_methods: "GET,PUT,OPTIONS"
+      }
     },
-    "plugins": {
-        "openid-connect": {
-            "discovery": "https://thunderid:${IDP_PORT}/.well-known/openid-configuration",
-            "bearer_only": true,
-            "token_signing_alg_values_expected": "RS256",
-            "set_userinfo_header": true,
-            "client_id": "$CLIENT_ID",
-            "client_secret": "$CLIENT_SECRET",
-            "use_jwks": true,
-            "ssl_verify": false,
-            "access_token_in_authorization_header": true
-        },
-        "cors": {
-            "allow_origins": "http://localhost:5173",
-            "allow_headers": "*",
-            "allow_methods": "GET,PUT,OPTIONS"
-        }
-    },
-    "id": "consent-endpoint"
-}
-EOF
+    id: "consent-endpoint"
+  }' | curl -s -o /dev/null -w "%{http_code}" \
+    --location --request PUT http://localhost:9180/apisix/admin/routes \
+    --header "Content-Type: application/json" \
+    --header "X-API-KEY: QuNGwapKysRvHfUtNkQFbUaGiiYeOcGo" \
+    --data @-)
 
-
-
-if [ $? -ne 0 ]; then
-    print_error "Failed to register consent engine routes"
+if [ "$CE_ROUTE_CODE" != "200" ] && [ "$CE_ROUTE_CODE" != "201" ]; then
+    print_error "Failed to register consent engine routes (HTTP $CE_ROUTE_CODE)"
     exit 1
 fi
 

--- a/members/run-member-services.sh
+++ b/members/run-member-services.sh
@@ -295,13 +295,18 @@ run_die() {
     fi
 
     print_step "Starting Online Passport App container..."
+    # This container is NOT on the exchange-network, so it reaches the published
+    # NDX ports via host.docker.internal (the same host alias the orchestration
+    # engine uses for data sources in ndx/fl-config.json). `localhost` here would
+    # mean the container itself, and we no longer detect a host IP.
     docker run -d \
         --name "$DIE_CONTAINER" \
         -p 3000:3000 \
         -e "CLIENT_ID=${M2M_CLIENT_ID}" \
         -e "CLIENT_SECRET=${M2M_CLIENT_SECRET}" \
-        -e "NDX_GRAPHQL_API_URL=http://${HOST_IP}:9081/public/graphql" \
-        -e "TOKEN_URL=https://${HOST_IP}:${IDP_PORT:-8090}/oauth2/token" \
+        -e "NDX_GRAPHQL_API_URL=http://host.docker.internal:9081/public/graphql" \
+        -e "TOKEN_URL=https://host.docker.internal:${IDP_PORT:-8090}/oauth2/token" \
+        --add-host=host.docker.internal:host-gateway \
         --restart unless-stopped \
         "$DIE_IMAGE"
 

--- a/ndx/.env
+++ b/ndx/.env
@@ -42,7 +42,10 @@ PORT_OE=4000
 # =============================================================================
 # GENERAL SERVICE CONFIGURATION
 # =============================================================================
-# Host address for services (0.0.0.0 for all interfaces)
+# Container bind address for the Go services (PDP, consent-engine). Must be
+# 0.0.0.0 so they listen on all interfaces and stay reachable across the Docker
+# network (APISIX->consent-engine, orchestration-engine->PDP). Binding to
+# localhost would restrict them to loopback and silently break those calls.
 HOST=0.0.0.0
 
 # JWT secret for authentication (REQUIRED in production - use strong secret)
@@ -111,9 +114,15 @@ OE_SCHEMA_PATH=./schema.graphql
 # IDP CONFIGURATION (ThunderID)
 # =============================================================================
 IDP_PORT=8090
-IDP_BASE_URL=https://thunderid:8090
-IDP_ISSUER=https://thunderid:8090
+# The OIDC issuer must resolve identically for the host browser AND the containers.
+# For this local-only stack we use `localhost`: the browser reaches it directly,
+# and ThunderID's bundled dev cert is CN=localhost (so the cert matches - only an
+# untrusted-CA click-through, no name mismatch). No /etc/hosts entry is needed.
+IDP_BASE_URL=https://localhost:8090
+IDP_ISSUER=https://localhost:8090
 IDP_AUDIENCE=CONSENT_PORTAL_APP
+# JWKS is fetched server-side (consent-engine) from inside the Docker network, so
+# it stays on the in-network `thunderid` hostname (resolved via Docker DNS).
 IDP_JWKS_URL=https://thunderid:8090/oauth2/jwks
 
 # ThunderID service configuration (ndx/docker-compose.yml thunderid* services)

--- a/ndx/config/thunderid/bootstrap/02-admin-cli.yaml
+++ b/ndx/config/thunderid/bootstrap/02-admin-cli.yaml
@@ -13,9 +13,11 @@
 #   2. a role granting `system` on the System resource server, assigned to the app.
 #
 # The role->app assignment is what makes admin-cli's client_credentials token carry
-# the `system` scope + audience, which init.sh uses to mint a management token:
+# the `system` scope + audience, which init.sh uses to mint a management token
+# (init.sh runs on the host and reaches ThunderID at the published localhost:8090
+# port, so no /etc/hosts entry is needed):
 #   curl -k -u ADMIN_CLI:$ADMIN_CLI_SECRET \
-#     -d 'grant_type=client_credentials&scope=system' https://thunderid:8090/oauth2/token
+#     -d 'grant_type=client_credentials&scope=system' https://localhost:8090/oauth2/token
 #
 # {{ .ADMIN_CLI_SECRET }} is resolved from the container environment at bootstrap
 # time (SubstituteEnvironmentVariables); the thunderid-setup service sets it.

--- a/ndx/docker-compose.yml
+++ b/ndx/docker-compose.yml
@@ -92,9 +92,10 @@ services:
       - PUBLIC_URL=${IDP_BASE_URL:-https://localhost:8090}
       - PORT=${IDP_PORT:-8090}
       - HOSTNAME=0.0.0.0
-      # CORS is no longer configured via deployment.yaml/env in 0.48. Allowed origins
-      # (Console + Consent Portal) are set at provisioning time by init.sh via
-      # PUT /server-config/cors (the server's dynamic CORS server-config section).
+      # CORS is no longer configured via deployment.yaml/env in 0.48. The Consent
+      # Portal origin is set at provisioning time by init.sh via PUT
+      # /server-config/cors (the server's dynamic CORS server-config section). The
+      # Console is served from the issuer, so its token calls are same-origin.
       - SMTP_HOST=${SMTP_HOST:-localhost}
       - SMTP_PORT=${SMTP_PORT:-1025}
       - SMTP_USERNAME=${SMTP_USERNAME:-dummy}

--- a/ndx/docker-compose.yml
+++ b/ndx/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-1234}
       - ADMIN_CLI_SECRET=${ADMIN_CLI_SECRET:-1234}
       - DIRECT_AUTH_SECRET=${DIRECT_AUTH_SECRET:-1234}
-      - PUBLIC_URL=${IDP_BASE_URL:-https://thunderid:8090}
+      - PUBLIC_URL=${IDP_BASE_URL:-https://localhost:8090}
       - PORT=${IDP_PORT:-8090}
       - HOSTNAME=0.0.0.0
       - SMTP_HOST=${SMTP_HOST:-localhost}
@@ -89,7 +89,7 @@ services:
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-1234}
       - ADMIN_CLI_SECRET=${ADMIN_CLI_SECRET:-1234}
       - DIRECT_AUTH_SECRET=${DIRECT_AUTH_SECRET:-1234}
-      - PUBLIC_URL=${IDP_BASE_URL:-https://thunderid:8090}
+      - PUBLIC_URL=${IDP_BASE_URL:-https://localhost:8090}
       - PORT=${IDP_PORT:-8090}
       - HOSTNAME=0.0.0.0
       # CORS is no longer configured via deployment.yaml/env in 0.48. Allowed origins
@@ -185,7 +185,7 @@ services:
       - DB_RETRY_DELAY=${DB_RETRY_DELAY:-1s}
       - CONSENT_PORTAL_URL=${CONSENT_PORTAL_URL:-http://localhost:5173}
       # Generic IdP config (verifier validates issuer + audience + client_id, no org).
-      - IDP_ISSUER=${IDP_ISSUER:-https://thunderid:8090}
+      - IDP_ISSUER=${IDP_ISSUER:-https://localhost:8090}
       - IDP_AUDIENCE=${IDP_AUDIENCE:-CONSENT_PORTAL_APP}
       - IDP_CLIENT_ID=${CONSENT_PORTAL_CLIENT_ID:-CONSENT_PORTAL_APP}
       - IDP_JWKS_URL=${IDP_JWKS_URL:-https://thunderid:8090/oauth2/jwks}
@@ -214,10 +214,11 @@ services:
     environment:
       - VITE_API_URL=http://localhost:9081/api/v1
       - VITE_CLIENT_ID=${CONSENT_PORTAL_CLIENT_ID:-consent-portal}
-      # NOTE: The default value for VITE_BASE_URL uses 'https://thunderid:8090'.
-      # Make sure 'thunderid' resolves correctly in your browser context (e.g., by adding it to /etc/hosts).
-      # See SETUP.md for more details.
-      - VITE_BASE_URL=${IDP_BASE_URL:-https://thunderid:8090}
+      # VITE_BASE_URL is the IdP the browser is redirected to for login, so it must
+      # be reachable from the browser. For this local stack IDP_BASE_URL is
+      # https://localhost:8090 (see ndx/.env) - the browser reaches it directly and
+      # ThunderID's dev cert is CN=localhost, so no /etc/hosts entry is required.
+      - VITE_BASE_URL=${IDP_BASE_URL:-https://localhost:8090}
       - VITE_SCOPE=openid profile email
       - VITE_SIGN_IN_REDIRECT_URL=http://localhost:5173
       - VITE_SIGN_OUT_REDIRECT_URL=http://localhost:5173


### PR DESCRIPTION
## What & why

ThunderID's OIDC issuer needs a single URL that resolves identically for the **host browser** and the **containers**. Until now that was bridged with a manual `/etc/hosts` entry (`127.0.0.1 thunderid`) or auto-detected host IP. This PR removes that requirement by using **`https://localhost:8090`** as the issuer for the local-only stack.

## Changes

- **Issuer → `https://localhost:8090`** everywhere browser-facing (`ndx/.env`, compose defaults, Consent Portal `VITE_BASE_URL`). ThunderID's bundled dev cert is `CN=localhost`, so the browser cert now *matches* (only an untrusted-CA click-through, no name mismatch).
- **Removed host-IP detection** from `init.sh`; its host-shell calls use `localhost`.
- **APISIX token validation → local public-key verification.** APISIX runs in a container where `localhost` ≠ ThunderID, so it can't fetch the discovery-advertised JWKS URL (`localhost:8090/oauth2/jwks`). It now verifies the RS256 signature against ThunderID's signing public key (extracted at init), with `valid_issuers` string-matching the issuer. _(Token introspection was tried first, but ThunderID rejects APISIX's `lua-resty-openidc` client-auth request format.)_
- **Passport container → `host.docker.internal`** (matches how the orchestration engine reaches data sources), removing the last `HOST_IP` usage.
- **`HOST` stays `0.0.0.0`** — it's the container *bind address*; `localhost` there makes PDP/consent-engine loopback-only and breaks cross-container calls.
- **`IDP_JWKS_URL` stays on `thunderid`** (Docker DNS) — consent-engine fetches it server-side from inside the network.
- Docs updated (`SETUP.md`, bootstrap comment).

## Verification (cold start)

- Discovery issuer = `https://localhost:8090`
- Gateway auth via `/public/graphql`: valid token → **200**, no token → **401**, garbage → **401**
- consent-engine fetches JWKS via `thunderid` from inside its container ✓
- Cross-container OE→PDP health → **200** (HOST fix)
- Consent flow returns the expected `CE_NOT_APPROVED` + consent-portal URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
